### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The board design allows for small breakout boards to be attached. There currentl
 
 Oh, the accompanying blog posts are [here](http://johan.kanflo.com/building-a-low-cost-wifi-camera/) and [here](http://johan.kanflo.com/a-versatile-esp8266-development-board/).
 
-###Usage
+### Usage
 
 Clone the ESP Open RTOS repository. See the documentation for how to add your SSID name and password.
 
@@ -48,7 +48,7 @@ Start the python script ```server.py``` and type ```upload:<your IP>``` to captu
 
 If you connect a [PIR module](http://www.ebay.com/sch/i.html?_trksid=PIR+module.TRS0&_nkw=PIR+module&_sacat=0) [eBay] to the JST connector you can use the command ```motion:on:<your ip>``` to have the board capture and upload an image when motion is detected.
 
-###Limitations
+### Limitations
 
 This is work in progress and there is currently very little error handling. Simultaneous clients will break the camera demo.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
